### PR TITLE
Report test duration to TeamCity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,3 @@ These versions are all fairly closely equivalent, just updated to cope with chan
 * **SBT v0.13** - use plugin **v1.5**
 
 The plugin is published to the main SBT plugin repository, so no further configuration should be necessary. 
-
-
-Known Limitations
-=================
-
-Sbt only reports that a test has been run when it completes. So this plugin has to
-tell TeamCity at that point that the test has both started and finished: this means
-TeamCity thinks that all your tests run *really* fast! Do not be misled...

--- a/src/main/scala/com/gu/TeamCityTestReporting.scala
+++ b/src/main/scala/com/gu/TeamCityTestReporting.scala
@@ -64,7 +64,7 @@ class TeamCityTestListener extends TestReportListener {
             println(s"Test:$testName was cancelled")
         }
 
-        teamcityReport("testFinished", "name" -> testName)
+        teamcityReport("testFinished", "name" -> testName, "duration" -> e.duration.toString)
       }
     }
   }


### PR DESCRIPTION
According to TeamCity documentation, `testFinished` has an optional `duration` attribute, and so does the new SBT test interface. I considered not including it if it is -1 (not reported by the test framework for some reason), but the automatic duration is useless anyway.
